### PR TITLE
Move clear to after resize so if height and width are calculated the …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,11 +32,11 @@ export default class SignatureCanvas extends Component {
 
   componentDidMount () {
     this._ctx = this._canvas.getContext("2d");
-    this.clear();
 
     this._handleMouseEvents();
     this._handleTouchEvents();
     this._resizeCanvas();
+    this.clear();
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
…background color gets set on the initial render.

When testing, if I didn't set a height and width and instead relied on offsetHeight and offsetWidth, the background color would not be set until the clear function was called manually. I think this is because in `componentDidMount` you were calling `this.clear()` before `this._resizeCanvas()` so the canvas didn't have any area to clear yet. Moving the clear to after resizeCanvas fixed the issue for me.
