### PR TITLE
Make reset on window resize optional

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,21 +13,22 @@ export default class SignatureCanvas extends Component {
     penColor: PropTypes.string,
     onEnd: PropTypes.func,
     onBegin: PropTypes.func,
-    canvasProps: PropTypes.object
+    canvasProps: PropTypes.object,
+    clearOnResize: PropTypes.bool
   }
-  constructor(props) {
-    super(props);
 
-    this.velocityFilterWeight = this.props.velocityFilterWeight || 0.7;
-    this.minWidth = this.props.minWidth || 0.5;
-    this.maxWidth = this.props.maxWidth || 2.5;
-    this.dotSize = this.props.dotSize || function () {
-        return (this.minWidth + this.maxWidth) / 2;
-    };
-    this.penColor = this.props.penColor || "black";
-    this.backgroundColor = this.props.backgroundColor || "rgba(0,0,0,0)";
-    this.onEnd = this.props.onEnd;
-    this.onBegin = this.props.onBegin;
+  static defaultProps = {
+    velocityFilterWeight: 0.7,
+    minWidth: 0.5,
+    maxWidth: 2.5,
+    dotSize: function (minWidth, maxWidth) {
+      return (minWidth + maxWidth) / 2;
+    },
+    penColor: 'black',
+    backgroundColor: 'rgba(0,0,0,0)',
+    onEnd: () => {},
+    onBegin: () => {},
+    clearOnResize: false
   }
 
   componentDidMount () {
@@ -47,7 +48,7 @@ export default class SignatureCanvas extends Component {
     let ctx = this._ctx
     let canvas = this._canvas
 
-    ctx.fillStyle = this.backgroundColor
+    ctx.fillStyle = this.props.backgroundColor
     ctx.clearRect(0, 0, canvas.width, canvas.height)
     ctx.fillRect(0, 0, canvas.width, canvas.height)
     this._reset()
@@ -109,9 +110,9 @@ export default class SignatureCanvas extends Component {
   _reset = () => {
     this.points = [];
     this._lastVelocity = 0;
-    this._lastWidth = (this.minWidth + this.maxWidth) / 2;
+    this._lastWidth = (this.props.minWidth + this.props.maxWidth) / 2;
     this._isEmpty = true;
-    this._ctx.fillStyle = this.penColor;
+    this._ctx.fillStyle = this.props.penColor;
   }
 
   _handleMouseEvents = () => {
@@ -120,7 +121,10 @@ export default class SignatureCanvas extends Component {
     this._canvas.addEventListener('mousedown', this._handleMouseDown)
     this._canvas.addEventListener('mousemove', this._handleMouseMove)
     document.addEventListener('mouseup', this._handleMouseUp)
-    window.addEventListener('resize', this._resizeCanvas)
+
+    if(this.props.clearOnResize) {
+      window.addEventListener('resize', this._resizeCanvas)
+    }
   }
 
   _handleTouchEvents = () => {
@@ -141,7 +145,9 @@ export default class SignatureCanvas extends Component {
     this._canvas.removeEventListener("touchmove", this._handleTouchMove)
     document.removeEventListener("touchend", this._handleTouchEnd)
 
-    window.removeEventListener("resize", this._resizeCanvas)
+    if(this.props.clearOnResize) {
+      window.removeEventListener("resize", this._resizeCanvas)
+    }
   }
 
   _handleMouseDown = (ev) => {
@@ -192,14 +198,12 @@ export default class SignatureCanvas extends Component {
   _strokeBegin = (ev) => {
     this._reset()
     this._strokeUpdate(ev)
-    if (typeof this.onBegin === 'function') {
-      this.onBegin(ev)
-    }
+    this.props.onBegin(ev)
   }
 
   _strokeDraw = (point) => {
     var ctx = this._ctx,
-        dotSize = typeof(this.dotSize) === 'function' ? this.dotSize() : this.dotSize;
+        dotSize = typeof(this.props.dotSize) === 'function' ? this.props.dotSize(this.props.minWidth, this.props.maxWidth) : this.props.dotSize;
 
     ctx.beginPath();
     this._drawPoint(point.x, point.y, dotSize);
@@ -214,9 +218,8 @@ export default class SignatureCanvas extends Component {
     if (!canDrawCurve && point) {
       this._strokeDraw(point);
     }
-    if (typeof this.onEnd === 'function') {
-      this.onEnd(ev)
-    }
+
+    this.props.onEnd(ev)
   }
 
   _createPoint = (ev) => {
@@ -280,8 +283,6 @@ export default class SignatureCanvas extends Component {
         velocity, newWidth;
 
     velocity = endPoint.velocityFrom(startPoint);
-    velocity = this.velocityFilterWeight * velocity
-        + (1 - this.velocityFilterWeight) * this._lastVelocity;
 
     newWidth = this._strokeWidth(velocity);
     this._drawCurve(curve, this._lastWidth, newWidth);
@@ -332,7 +333,7 @@ export default class SignatureCanvas extends Component {
   }
 
   _strokeWidth = (velocity) => {
-    return Math.max(this.maxWidth / (velocity + 1), this.minWidth);
+    return Math.max(this.props.maxWidth / (velocity + 1), this.props.minWidth);
   }
 
   render () {


### PR DESCRIPTION
Although resetting the canvas is the easiest way of going about it, in some cases it won't work. With this PR the `clearOnResize` prop is introduces.

In addition to this I moved the default value from the constructur to defaultProps.