### PR TITLE
Fix PropTypes deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "webpack-dev-server": "^1.10.1"
   },
   "peerDependencies": {
+    "prop-types": "^15.5.8",
     "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
 import trimCanvas from 'trim-canvas'
 
 import Bezier from './bezier.js'


### PR DESCRIPTION
Using PropTypes from React will become deprecated, the 'prop-types' library has been released instead.