### PR TITLE
Fixed broken image in example

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -32,7 +32,7 @@ class App extends Component {
       </div>
       {trimmedDataURL
         ? <img className={styles.sigImage}
-          style={{backgroundImage: 'url(' + trimmedDataURL + ')'}} />
+          src={trimmedDataURL} />
         : null}
     </div>
   }


### PR DESCRIPTION
In the example, the signature base64 image was being set to the background of the `<image>` element, which seemed weird to me and showed a broken icon with the actual image as background. This way it shows properly.