### PR TITLE
Fixed error when drawing single dot.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,8 @@ export default class SignatureCanvas extends Component {
     velocityFilterWeight: 0.7,
     minWidth: 0.5,
     maxWidth: 2.5,
-    dotSize: () => {
-      return this ? (this.props.minWidth + this.props.maxWidth) / 2 : 2
+    dotSize: (minWidth, maxWidth) => {
+      return ((minWidth || 0.5) + (maxWidth || 2.5)) / 2
     },
     penColor: 'black',
     backgroundColor: 'rgba(0,0,0,0)',
@@ -198,7 +198,10 @@ export default class SignatureCanvas extends Component {
   _strokeDraw = (point) => {
     let ctx = this._ctx
     let dotSize = typeof(this.props.dotSize) === 'function'
-      ? this.props.dotSize()
+      ? this.props.dotSize(
+        this.props.minWidth,
+        this.props.maxWidth
+      )
       : this.props.dotSize
 
     ctx.beginPath();

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export default class SignatureCanvas extends Component {
     minWidth: 0.5,
     maxWidth: 2.5,
     dotSize: () => {
-      return (this.props.minWidth + this.props.maxWidth) / 2
+      return this ? (this.props.minWidth + this.props.maxWidth) / 2 : 2
     },
     penColor: 'black',
     backgroundColor: 'rgba(0,0,0,0)',


### PR DESCRIPTION
When drawing a single point, the canvas would remain empty and the following error would pop on the console:

```
TypeError: undefined has no properties[Learn More]
dotsize
index.js:25:6
```

This PR fixes that issue. I was having a problem with this because the canvas would look empty but the state of the component would contain a blank image.
