### PR TITLE
when loading fromDataURL, resize canvas before drawing image on canvas

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,7 @@ export default class SignatureCanvas extends Component {
     let height = this._canvas.height / ratio
 
     this._reset()
+    this._resizeCanvas()
     image.onload = () => this._ctx.drawImage(image, 0, 0, width, height)
     image.src = dataURL
     this._isEmpty = false


### PR DESCRIPTION
#6 

Have the canvas resize before drawing the canvas, will properly scale the image.