### PR TITLE
Add compatilibity to React 16 without warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.8",
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "trim-canvas": "^0.1.0"


### PR DESCRIPTION
`react-signature-canvas` seems to work flawlessly with React 16 and React DOM 16 but the `package.json` does not reflect that, cause warnings to be thrown when installing dependencies.

```
warning "react-signature-canvas@0.1.7" has incorrect peer dependency "react@^0.14.0 || ^15.0.0".
warning "react-signature-canvas@0.1.7" has incorrect peer dependency "react-dom@^0.14.0 || ^15.0.0".
```