### PR TITLE
Added 'On' function to rebind event handlers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,6 +142,11 @@ export default class SignatureCanvas extends Component {
     document.addEventListener('touchend', this._handleTouchEnd)
   }
 
+  on = () => {
+    this._handleMouseEvents();
+    this._handleTouchEvents();
+  }
+
   off = () => {
     this._canvas.removeEventListener('mousedown', this._handleMouseDown)
     this._canvas.removeEventListener('mousemove', this._handleMouseMove)


### PR DESCRIPTION
It looks like there is an `off` function to disable the canvas but no `on` function to rebind all event handlers once the canvas is disabled. I've tested on my local repo and this seems to work fine.

Would be good to have this feature.