### PR TITLE
Import Signature pad from it's source file.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import SignaturePad from 'signature_pad'
+import SignaturePad from 'signature_pad/dist/signature_pad.js'
 import trimCanvas from 'trim-canvas'
 
 export default class SignatureCanvas extends Component {


### PR DESCRIPTION
See issue https://github.com/agilgur5/react-signature-canvas/issues/23, which references, https://github.com/szimek/signature_pad/issues/257. 

There is a bug in Create React App, that will cause a crash because of the signature_pad import. 

The workaround suggested is to import the js file directly.