### PR TITLE
various small docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,15 @@ The API methods are _mostly_ just wrappers around [`signature_pad`'s API](https:
 
 ## Example
 
+Have a look at the [`example/`](example/) directory.
+
+This example can be run with:
+
 ```bash
 npm start
 ```
 
-Navigate to [http://localhost:8080/](http://localhost:8080/) in your browser and you should be able to see the signature canvas in action.
-
-The source code for this example is found in the [`example/`](example/) directory.
+followed by navigating to [http://localhost:8080/](http://localhost:8080/) in your browser to view it.
 
 ## [Demo](https://agilgur5.github.io/react-signature-canvas/)
 

--- a/README.md
+++ b/README.md
@@ -102,3 +102,8 @@ npm start
 Navigate to [http://localhost:8080/](http://localhost:8080/) in your browser and you should be able to see the signature canvas in action.
 
 The source code for this example is found in the [`example/`](example/) directory.
+
+## [Demo](https://agilgur5.github.io/react-signature-canvas/)
+
+[View the live demo here](https://agilgur5.github.io/react-signature-canvas/).
+Hosted via the [`gh-pages` branch](https://github.com/agilgur5/react-signature-canvas/tree/gh-pages), which has a standalone version of the code in [`example/`](example/).

--- a/README.md
+++ b/README.md
@@ -13,16 +13,11 @@
 
 A React wrapper component around [signature_pad](https://github.com/szimek/signature_pad).
 
-Originally, this was just an _unopinionated_ fork of
-[react-signature-pad](https://github.com/blackjk3/react-signature-pad)
-that did not impose any styling or wrap any other unwanted elements around
-your canvas -- it's just a wrapper around a single canvas element! Hence the
-naming difference.
+Originally, this was just an _unopinionated_ fork of [react-signature-pad](https://github.com/blackjk3/react-signature-pad) that did not impose any styling or wrap any other unwanted elements around your canvas -- it's just a wrapper around a single canvas element!
+Hence the naming difference.
 Nowadays, this repo / library has significantly evolved, introducing new features, fixing various bugs, and now wrapping the upstream `signature_pad` to have its updates and bugfixes baked in.
 
-This fork also allows you to directly pass [props](#props) to the underlying
-canvas element, has new, documented [API methods](#api) you can use, and has
-new, documented [props](#props) you can pass to it.
+This fork also allows you to directly pass [props](#props) to the underlying canvas element, has new, documented [API methods](#api) you can use, and has new, documented [props](#props) you can pass to it.
 
 ## Installation
 
@@ -44,8 +39,8 @@ ReactDOM.render(
 
 ### Props
 
-The props of SignatureCanvas mainly control the properties of the pen stroke
-used in drawing. All props are **optional**.
+The props of SignatureCanvas mainly control the properties of the pen stroke used in drawing.
+All props are **optional**.
 
 - `velocityFilterWeight` : `number`, default: `0.7`
 - `minWidth` : `number`, default: `0.5`
@@ -56,8 +51,7 @@ used in drawing. All props are **optional**.
 - `penColor` : `string`, default: `'black'`
 - `throttle`: `number`, default: `16`
 
-There are also two callbacks that will be called when a stroke ends and one
-begins, respectively.
+There are also two callbacks that will be called when a stroke ends and one begins, respectively.
 
 - `onEnd` : `function`
 - `onBegin` : `function`
@@ -67,8 +61,7 @@ Additional props are used to control the canvas element.
 - `canvasProps`: `object`
   - directly passed to the underlying `<canvas />` element
 - `backgroundColor` : `string`, default: `'rgba(0,0,0,0)'`
-  - used in the [API's](#api) `clear` convenience method (which itself is
-    called internally during resizes)
+  - used in the [API's](#api) `clear` convenience method (which itself is called internally during resizes)
 - `clearOnResize`: `bool`, default: `true`
   - whether or not the canvas should be cleared when the window resizes
 
@@ -77,8 +70,7 @@ Of these props, all, except for `canvasProps` and `clearOnResize`, are passed th
 
 ### API
 
-All API methods require a ref to the SignatureCanvas in order to use and are
-instance methods of the ref.
+All API methods require a ref to the SignatureCanvas in order to use and are instance methods of the ref.
 
 ```javascript
 <SignatureCanvas ref={(ref) => { this.sigCanvas = ref }} />
@@ -92,10 +84,9 @@ instance methods of the ref.
 - `toData()`: `pointGroupArray`, returns signature image as an array of point groups
 - `off()`: `void`, unbinds all event handlers
 - `on()`: `void`, rebinds all event handlers
-- `getCanvas()`: `canvas`, returns the underlying canvas ref. Allows you to
-  modify the canvas however you want or call methods such as `toDataURL()`
-- `getTrimmedCanvas()`: `canvas`, creates a copy of the canvas and returns a
-  trimmed version of it, with all whitespace removed.
+- `getCanvas()`: `canvas`, returns the underlying canvas ref.
+  Allows you to modify the canvas however you want or call methods such as `toDataURL()`
+- `getTrimmedCanvas()`: `canvas`, creates a copy of the canvas and returns a trimmed version of it, with all whitespace removed.
 - `getSignaturePad()`: `SignaturePad`, returns the underlying SignaturePad reference.
 
 The API methods are _mostly_ just wrappers around [`signature_pad`'s API](https://github.com/szimek/signature_pad#api).
@@ -108,8 +99,6 @@ The API methods are _mostly_ just wrappers around [`signature_pad`'s API](https:
 $ npm start
 ```
 
-Navigate to [http://localhost:8080/](http://localhost:8080/) in your browser
-and you should be able to see the signature canvas in action.
+Navigate to [http://localhost:8080/](http://localhost:8080/) in your browser and you should be able to see the signature canvas in action.
 
-The source code for this example is found in the [`example/`](example/)
-directory.
+The source code for this example is found in the [`example/`](example/) directory.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The API methods are _mostly_ just wrappers around [`signature_pad`'s API](https:
 ## Example
 
 ```bash
-$ npm start
+npm start
 ```
 
 Navigate to [http://localhost:8080/](http://localhost:8080/) in your browser and you should be able to see the signature canvas in action.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ All API methods require a ref to the SignatureCanvas in order to use and are ins
 - `on()`: `void`, rebinds all event handlers
 - `getCanvas()`: `canvas`, returns the underlying canvas ref.
   Allows you to modify the canvas however you want or call methods such as `toDataURL()`
-- `getTrimmedCanvas()`: `canvas`, creates a copy of the canvas and returns a trimmed version of it, with all whitespace removed.
+- `getTrimmedCanvas()`: `canvas`, creates a copy of the canvas and returns a [trimmed version](https://github.com/agilgur5/trim-canvas) of it, with all whitespace removed.
 - `getSignaturePad()`: `SignaturePad`, returns the underlying SignaturePad reference.
 
 The API methods are _mostly_ just wrappers around [`signature_pad`'s API](https://github.com/szimek/signature_pad#api).


### PR DESCRIPTION
- (format): 1 sentence = 1 line for docs  …
- (fix/docs): remove `$` sign from example code block  …
- (docs): add link to `trim-canvas`  …
- (docs): add Demo section linking to new live demo  …
- (docs): modify Example section wording due to Demo

Example and Demo section are specific things to look at, the rest is just formatting. also a link was added to `getTrimmedCanvas()` description