### PR TITLE
add React 17 to peerDep range

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.8",
-    "react": "0.14 - 16",
-    "react-dom": "0.14 - 16"
+    "react": "0.14 - 17",
+    "react-dom": "0.14 - 17"
   },
   "dependencies": {
     "signature_pad": "^2.3.2",


### PR DESCRIPTION
Fixes npm 7 install errors (really warnings) 

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: example@1.0.0
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"^17.0.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"0.14 - 16" from react-signature-canvas@1.0.3
npm ERR! node_modules/react-signature-canvas
npm ERR!   react-signature-canvas@"*" from the root project
```