### PR TITLE
fix: don't clear canvas on mobile browsers' height change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,9 @@ import React, { Component } from 'react'
 import SignaturePad from 'signature_pad'
 import trimCanvas from 'trim-canvas'
 
+const userAgent = window.navigator.userAgent
+const isTouchDevice = userAgent.indexOf("iPhone") >= 0 || userAgent.indexOf("iPad") >= 0 || userAgent.indexOf("Android") >= 0
+
 export default class SignatureCanvas extends Component {
   static propTypes = {
     // signature_pad's props
@@ -25,6 +28,8 @@ export default class SignatureCanvas extends Component {
   }
 
   _sigPad = null
+
+  _windowSize = { width: window.innerWidth, height: window.innerHeight }
 
   _excludeOurProps = () => {
     const { canvasProps, clearOnResize, ...sigPadProps } = this.props
@@ -67,11 +72,28 @@ export default class SignatureCanvas extends Component {
     return this._sigPad
   }
 
-  _checkClearOnResize = () => {
-    if (!this.props.clearOnResize) {
+  _handleResize = (callback) => {
+    if (this._windowSize.width === window.innerWidth &&
+      /**
+       * For touch devices, only compare width as the browser height
+       * might constantly change as user scrolls/touches like on iOS Safari.
+       */
+      (this._windowSize.height === window.innerHeight || isTouchDevice)
+    ) {
       return
     }
-    this._resizeCanvas()
+    // Update window size
+    this._windowSize = { width: window.innerWidth, height: window.innerHeight }
+    callback()
+  }
+
+  _checkClearOnResize = () => {
+    this._handleResize(() => {
+      if (!this.props.clearOnResize) {
+        return
+      }
+      this._resizeCanvas()
+    })
   }
 
   _resizeCanvas = () => {


### PR DESCRIPTION
The resize events kept being triggered when user scrolled/touched on the mobile browser like Safari on iOS 15,
as the window height changed a little bit if a user scrolled/touched, particularly on iOS Safari the navigation bar will keep expand/collapse as user scrolls.

Fixes https://github.com/agilgur5/react-signature-canvas/issues/65

Related links for resize problem:
https://titanwolf.org/Network/Articles/Article?AID=488d4b0c-53df-4102-99af-6983a915ea8d
https://stackoverflow.com/questions/8898412/iphone-ipad-triggering-unexpected-resize-events

