### PR TITLE
optim: add `assumptions` to Babel config, mirroring previous config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,6 +11,12 @@ module.exports = api => {
   if (isTest) presetEnv[1] = { ...presetEnv[1], ...jestTargets }
 
   return {
+    // @ts-expect-error -- @types/babel__core doesn't specify assumptions yet
+    assumptions: {
+      // optimizations equivalent to previous Babel 6 "loose" behavior for preset-stage-2 (https://github.com/babel/rfcs/blob/main/rfcs/0003-top-level-assumptions.md#assumptions-list, https://github.com/babel/babel/tree/v7.5.5/packages/babel-preset-stage-2)
+      setPublicClassFields: true,
+      constantSuper: true
+    },
     presets: [
       presetEnv,
       '@babel/preset-typescript',


### PR DESCRIPTION
## Summary

Optimize output by adding `assumptions` to the Babel config, which mirrors the previous build system's config that uses Babel 7.
- By previous, I mean the several year old one prior to #42 

## Details

- previously used Babel 6's preset-stage-2, which, in Babel 7, is the equivalent of turning on `loose` in `proposal-class-properties`:
  https://github.com/babel/babel/tree/v7.5.5/packages/babel-preset-stage-2

- top-level `assumptions` replace the old `loose` configurations:
  https://github.com/babel/rfcs/blob/main/rfcs/0003-top-level-assumptions.md#assumptions-list

- this makes the minified UMD size ~20% smaller, very close to the size it was previously w/ Babel 6
  - basically the size increase was, in part, due to added spec-compliancy cases
    - and we don't actually need that stricter spec-compliancy in this codebase's small usage, so we can add "assumptions" to have the compiler optimize more by skipping some checks / edge cases that are unnecessary in this case

- as a double-check measure, I compared the old package's minified UMD to see if it had the helpers in it
  - this was a bit hard to do as it was minified after all, but I was able to more-or-less correlate all the helpers with either error messages in the helper code (which can't be minified), or specific methods or properties that aren't normally touched (e.g. `enumerable`)
    - prev minified UMD: https://unpkg.com/react-signature-canvas@1.0.5/build/index.js
    - Babel helper code: https://github.com/babel/babel/blob/a24c1d047e6db77c32d9505c6876897b4c3689d2/packages/babel-helpers/src/helpers.ts#L207

  - this looks be a good bit closer to the old build's results, but should still be wary of possible legacy compat issues and **note that in the release notes**
    - in particular, the implicit update to `compat-table` that happened during upgrading of the build system, which would change what `defaults` means for `browserslist` etc
    
## History

I knew the output was different (and larger) due to spec-compliancy changes, but somehow didn't think about adding `loose` etc as an optimization until I saw Babel's `assumptions` RFC. I thought I wrote about the output differences in https://github.com/agilgur5/react-signature-canvas/pull/42#pullrequestreview-947783313 , but I guess I didn't? Couldn't find it in a commit message either, but could've sworn I wrote it down somewhere...
