### PR TITLE
optim: specify version in `@babel/plugin-transform-runtime`

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,12 @@
+const pkgJson = require('./package.json')
+
+const runtimeVersion = pkgJson.dependencies['@babel/runtime']
+// eslint-disable-next-line dot-notation -- this conflicts with tsc, possibly due to outdated ESLint
+const NODE_ENV = process.env['NODE_ENV']
+
 /** @type {import('@babel/core').ConfigFunction} */
 module.exports = api => {
-  // eslint-disable-next-line dot-notation -- this conflicts with tsc, possibly due to outdated ESLint
-  api.cache.using(() => process.env['NODE_ENV']) // cache based on NODE_ENV
+  api.cache.using(() => NODE_ENV + '_' + runtimeVersion) // cache based on NODE_ENV and runtimeVersion
 
   // normally use browserslistrc, but for Jest, use current version of Node
   const isTest = api.env('test')
@@ -18,7 +23,10 @@ module.exports = api => {
     ],
     plugins: [
       // used with @rollup/plugin-babel
-      '@babel/plugin-transform-runtime'
+      ['@babel/plugin-transform-runtime', {
+        regenerator: false, // not used, and would prefer babel-polyfills over this anyway
+        version: runtimeVersion // @babel/runtime's version
+      }]
     ]
   }
 }


### PR DESCRIPTION
## Summary

Specify a `version` in `@babel/plugin-transform-runtime`'s config to further optimize the output with newer helpers.

## Details

- the default is 7.0.0, but we are on a newer version, so we can use newer / more optimized helpers
  - `createSuper` now seems to be used, which required 7.9.0:
    https://github.com/babel/babel/blob/9199565fa08d840c8f1cc86c1b22be119b538f2f/packages/babel-helpers/src/helpers.ts#L624
    - this seems to replace the `possibleConstructorReturn` and `getPrototypeOf` helpers

- roughly ~6% minified size decrease as a result!

- change `babel.config.js`'s caching to include `@babel/runtime`'s version since we would need to rebuild if it changes

## Misc

Noticed that this was a field when stumbling upon the [`@babel/plugin-transform-runtime` options in the Babel docs](https://babeljs.io/docs/en/babel-plugin-transform-runtime#options).
Tested this simultaneously with #79 as they both affect the output