### PR TITLE
deps: use `rollup-plugin-node-externals`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "rollup": "^2.70.2",
+        "rollup-plugin-node-externals": "^4.0.0",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-typescript2": "^0.31.2",
         "ts-node": "^10.7.0",
@@ -12905,6 +12906,92 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-node-externals": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-externals/-/rollup-plugin-node-externals-4.0.0.tgz",
+      "integrity": "sha512-7L0lqN+AEJqS13x240F5zyArHn2tNpHC7Ju8vtS893DkutIU89k5v3A7jhnOqLvOXAzjm9Ha7UZdwHOPyqiPDQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "rollup": ">=2.60.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.60.0"
+      }
+    },
+    "node_modules/rollup-plugin-node-externals/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rollup-plugin-node-externals/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rollup-plugin-node-externals/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rollup-plugin-node-externals/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rollup-plugin-node-externals/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/rollup-plugin-terser": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
@@ -24341,6 +24428,60 @@
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "rollup-plugin-node-externals": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-externals/-/rollup-plugin-node-externals-4.0.0.tgz",
+      "integrity": "sha512-7L0lqN+AEJqS13x240F5zyArHn2tNpHC7Ju8vtS893DkutIU89k5v3A7jhnOqLvOXAzjm9Ha7UZdwHOPyqiPDQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
       }
     },
     "rollup-plugin-terser": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "rollup": "^2.70.2",
+    "rollup-plugin-node-externals": "^4.0.0",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.31.2",
     "ts-node": "^10.7.0",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,5 +1,6 @@
 import type { IPackageJson } from 'package-json-type'
-import type { IsExternal, RollupOptions, OutputOptions } from 'rollup'
+import type { RollupOptions, OutputOptions } from 'rollup'
+import { externals } from 'rollup-plugin-node-externals'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import { babel } from '@rollup/plugin-babel'
@@ -9,24 +10,6 @@ import { terser } from 'rollup-plugin-terser'
 import packageJson from './package.json'
 
 const pkgJson = packageJson as IPackageJson // coerce to the right type
-
-// treat deps and peerDeps as externals -- don't bundle them
-const depsList = [
-  ...Object.keys(pkgJson.dependencies ?? []),
-  ...Object.keys(pkgJson.peerDependencies ?? [])
-]
-
-// TODO: split this into a rollup plugin? submodule match is often missing
-const isExternal: IsExternal = (id) => {
-  // simple case: exact match (ex: '@babel/runtime')
-  if (depsList.includes(id)) return true
-  // submodule match (ex: '@babel/runtime/helpers/get')
-  for (const dep of depsList) {
-    if (id.startsWith(dep)) return true
-  }
-  // otherwise false
-  return false
-}
 
 const outputDefaults: OutputOptions = {
   // always provide a sourcemap for better debugging for consumers
@@ -56,8 +39,8 @@ const configs: RollupOptions[] = [{
     })],
     ...outputDefaults
   }],
-  external: isExternal,
   plugins: [
+    externals(), // https://github.com/Septh/rollup-plugin-node-externals#3-order-matters
     nodeResolve(),
     commonjs(),
     babel({


### PR DESCRIPTION
## Summary

Use [`rollup-plugin-node-externals`](https://github.com/Septh/rollup-plugin-node-externals) instead of custom `external` code

## Details

- instead of the custom JS code I wrote
  - I was thinking of separating that into a plugin, but someone already did that!
    - and, importantly, also covered submodules, unlike _most_ of the externals plugins (e.g. https://github.com/stevenbenisek/rollup-plugin-auto-external/issues/16)
      - see regex here: https://github.com/Septh/rollup-plugin-node-externals/blob/11a7b4454f57c76436e71ecead0cc59ab0cc3b80/src/index.ts#L106

- put it _before_ `node-resolve` as the docs state

- reduces my code a bit, which is always nice, and will make it easier to split my Rollup config into its own "preset" package later on