### PR TITLE
deps: use `@agilgur5/tsconfig` to simplify `tsconfig`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@agilgur5/changelog-maker": "^3.0.0",
+        "@agilgur5/tsconfig": "^0.0.1",
         "@babel/core": "^7.17.9",
         "@babel/plugin-transform-runtime": "^7.17.0",
         "@babel/preset-env": "^7.16.11",
@@ -28,7 +29,6 @@
         "@rollup/plugin-babel": "^5.3.1",
         "@rollup/plugin-commonjs": "^21.1.0",
         "@rollup/plugin-node-resolve": "^13.2.1",
-        "@tsconfig/strictest": "^1.0.1",
         "@types/enzyme": "^3.10.4",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.6",
         "canvas": "^2.9.1",
@@ -110,6 +110,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@agilgur5/tsconfig": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@agilgur5/tsconfig/-/tsconfig-0.0.1.tgz",
+      "integrity": "sha512-Q/Rwf0DjxOh3DXnKbLauBAWuVFOWHTm1ViwlHhdGEiCv/jdwCwIJjYh9NmYmfgcGnTTDlcShHG7x2C+7Xsd9ag==",
+      "dev": true,
+      "dependencies": {
+        "@tsconfig/strictest": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/agilgur5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -14883,6 +14898,15 @@
             "ansi-regex": "^4.0.0"
           }
         }
+      }
+    },
+    "@agilgur5/tsconfig": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@agilgur5/tsconfig/-/tsconfig-0.0.1.tgz",
+      "integrity": "sha512-Q/Rwf0DjxOh3DXnKbLauBAWuVFOWHTm1ViwlHhdGEiCv/jdwCwIJjYh9NmYmfgcGnTTDlcShHG7x2C+7Xsd9ag==",
+      "dev": true,
+      "requires": {
+        "@tsconfig/strictest": "^1.0.0"
       }
     },
     "@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   },
   "devDependencies": {
     "@agilgur5/changelog-maker": "^3.0.0",
+    "@agilgur5/tsconfig": "^0.0.1",
     "@babel/core": "^7.17.9",
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
@@ -88,7 +89,6 @@
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^21.1.0",
     "@rollup/plugin-node-resolve": "^13.2.1",
-    "@tsconfig/strictest": "^1.0.1",
     "@types/enzyme": "^3.10.4",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.6",
     "canvas": "^2.9.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,11 @@
 {
-  // https://github.com/tsconfig/bases
-  "extends": "@tsconfig/strictest/tsconfig.json",
+  // https://github.com/agilgur5/tsconfig
+  "extends": "@agilgur5/tsconfig/src/tsconfig.library.json",
   // exclude node_modules (the default), dist dir, coverage dir, and example for now
   "exclude": ["node_modules/", "dist/", "coverage/", "example/"],
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
   "compilerOptions": {
     // output to dist/ dir
     "outDir": "dist/",
-    // output .d.ts declaration files for consumers
-    "declaration": true,
-    // output .d.ts.map declaration map files for consumers
-    "declarationMap": true,
-    // output .js.map sourcemap files for consumers
-    "sourceMap": true,
-    // use Node's module resolution algorithm, instead of the legacy TS one
-    "moduleResolution": "node",
-    // resolve JSON files
-    "resolveJsonModule": true,
-    // transpile JSX to React.createElement
-    "jsx": "react",
-    // ignored during builds, but commonly used when type-checking with `tsc`
-    "noEmit": true,
   }
 }


### PR DESCRIPTION
## Summary

Simplify `tsconfig.json` by using my own `tsconfig`, [`@agilgur5/tsconfig`](https://github.com/agilgur5/tsconfig).

## Details

- this is my own `tsconfig` base built on top of [`@tsconfig/strictest`](https://github.com/tsconfig/bases)
  - as you can see, it just reduces all the non-type-checking related config that `@tsconfig/strictest` doesn't cover

- TS doesn't yet support package `exports` for `tsconfig`s yet (https://github.com/microsoft/TypeScript/issues/48665), hence the longer path into the package

- Relative paths in `tsconfig` bases are also relative _within_ `node_modules` (https://github.com/microsoft/TypeScript/issues/29172), so have to repeat any relative paths here
  - And due to this, I think it's better right now for `build` to extend the base here instead of the `build` tsconfig in `@agilgur5/tsconfig`
    - I didn't fully think that one through when I made it tbh, though it still serves as a good example `tsconfig`
    - Maybe that will be different in the future if TS changes or otherwise comes up with a solution to this (see the issue)