### PR TITLE
deps: change `prop-types` from peerDep to plain dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "changelog": "changelog-maker"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.8",
     "react": "0.14 - 18",
     "react-dom": "0.14 - 18"
   },
@@ -73,6 +72,7 @@
     "@types/prop-types": "^15.7.3",
     "@types/react": "^18.0.12",
     "@types/signature_pad": "^2.3.0",
+    "prop-types": "^15.5.8",
     "signature_pad": "^2.3.2",
     "trim-canvas": "^0.1.0"
   },


### PR DESCRIPTION
prop-types aren't installed automatically when react-signature-canvas was installed.

![image](https://github.com/agilgur5/react-signature-canvas/assets/61571063/92ae112f-4837-4fc6-8fba-e4fc0149e080)