### PR TITLE
deps: add React 19 to peerDep range, remove React devDeps -- needs devDeps, lockfile, typings, and test updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/runtime": "^7.17.9",
         "@types/prop-types": "^15.7.3",
-        "@types/react": "^18.0.12",
+        "@types/react": "^19.0.2",
         "@types/signature_pad": "^2.3.0",
         "signature_pad": "^2.3.2",
         "trim-canvas": "^0.1.0"
@@ -36,8 +36,6 @@
         "jest-config": "^27.5.1",
         "package-json-type": "^1.0.3",
         "parcel": "^2.4.1",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
         "rollup": "^2.70.2",
         "rollup-plugin-node-externals": "^4.0.0",
         "rollup-plugin-terser": "^7.0.2",
@@ -52,8 +50,8 @@
       },
       "peerDependencies": {
         "prop-types": "^15.5.8",
-        "react": "0.14 - 18",
-        "react-dom": "0.14 - 18"
+        "react": "0.14 - 19",
+        "react-dom": "0.14 - 19"
       }
     },
     "node_modules/@agilgur5/changelog-maker": {
@@ -4942,12 +4940,10 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "node_modules/@types/react": {
-      "version": "18.0.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.12.tgz",
-      "integrity": "sha512-duF1OTASSBQtcigUvhuiTB1Ya3OvSy+xORCiEf20H0P0lzx+/KeVsA99U5UjLXSbyo1DRJDlLKqTeM1ngosqtg==",
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.2.tgz",
+      "integrity": "sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==",
       "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
@@ -4968,11 +4964,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/signature_pad": {
       "version": "2.3.0",
@@ -12199,7 +12190,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -12211,7 +12202,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -12693,7 +12684,7 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -18033,12 +18024,10 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "18.0.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.12.tgz",
-      "integrity": "sha512-duF1OTASSBQtcigUvhuiTB1Ya3OvSy+xORCiEf20H0P0lzx+/KeVsA99U5UjLXSbyo1DRJDlLKqTeM1ngosqtg==",
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.2.tgz",
+      "integrity": "sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==",
       "requires": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
@@ -18059,11 +18048,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/signature_pad": {
       "version": "2.3.0",
@@ -23542,7 +23526,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -23551,7 +23535,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -23907,7 +23891,7 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -65,13 +65,13 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.8",
-    "react": "0.14 - 18",
-    "react-dom": "0.14 - 18"
+    "react": "0.14 - 19",
+    "react-dom": "0.14 - 19"
   },
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@types/prop-types": "^15.7.3",
-    "@types/react": "^18.0.12",
+    "@types/react": "^19.0.2",
     "@types/signature_pad": "^2.3.0",
     "signature_pad": "^2.3.2",
     "trim-canvas": "^0.1.0"
@@ -96,8 +96,6 @@
     "jest-config": "^27.5.1",
     "package-json-type": "^1.0.3",
     "parcel": "^2.4.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "rollup": "^2.70.2",
     "rollup-plugin-node-externals": "^4.0.0",
     "rollup-plugin-terser": "^7.0.2",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ export interface SignatureCanvasProps extends SignaturePad.SignaturePadOptions {
 }
 
 export class SignatureCanvas extends Component<SignatureCanvasProps> {
-  static propTypes = {
+  static override propTypes = {
     // signature_pad's props
     velocityFilterWeight: PropTypes.number,
     minWidth: PropTypes.number,

--- a/test/index.spec.tsx
+++ b/test/index.spec.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { SignatureCanvas, SignatureCanvasProps } from '../src/index'
 import { propsF, dotF } from './fixtures'
 
-function renderSCWithRef (props?: SignatureCanvasProps): { wrapper: RenderResult, instance: SignatureCanvas, ref: React.RefObject<SignatureCanvas> } {
+function renderSCWithRef (props?: SignatureCanvasProps): { wrapper: RenderResult, instance: SignatureCanvas, ref: React.RefObject<SignatureCanvas | null> } {
   const ref = React.createRef<SignatureCanvas>()
   const wrapper = render(<SignatureCanvas {...props} ref={ref} />)
   const instance = ref.current! // eslint-disable-line @typescript-eslint/no-non-null-assertion -- this simplifies the code; it does exist immediately after render. it won't exist after unmount, but we literally test for that separately


### PR DESCRIPTION
Fixes #109. Replaces #110

Per https://github.com/agilgur5/react-signature-canvas/issues/109#issuecomment-2561889695, I removed the main react and react-dom dependencies, and just left the peer ones to help with compatibility