### PR TITLE
fix(ci): run GH action on external PRs as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [push, pull_request]
 jobs:
   ci:
     name: CI - Node ${{ matrix.node-version }}, ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Add `pull_request` to [GHA `on` config](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#using-multiple-events)

## Details

- `push` works for all PRs from my own branches, but not for PRs from forks from external contributors
  - see also https://github.com/agilgur5/mst-persist/pull/33/commits/c890d142a96eb54cc768f408ad87e93d07ee8a6e
  
#110 and #111 are not running CI because this was missing per https://github.com/agilgur5/react-signature-canvas/issues/109#issuecomment-2561507935