### PR TITLE
fix(ci): temporarily pin matrix to Node 16 on Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # TODO: add back Node 18 once node-canvas is properly supported: https://github.com/Automattic/node-canvas/issues/2025
-        node-version: [14.x, 16.x] # LTS Node: https://nodejs.org/en/about/releases/
+        node-version: [16.x, 18.x] # LTS Node: https://nodejs.org/en/about/releases/
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x, 18.x] # LTS Node: https://nodejs.org/en/about/releases/
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        # TODO: add back Node 18 once node-canvas is properly supported: https://github.com/Automattic/node-canvas/issues/2025
+        node-version: [16.x] # LTS Node: https://nodejs.org/en/about/releases/
+        os: [ubuntu-latest]
 
     steps:
     - name: Checkout repo


### PR DESCRIPTION
## Summary

Use `node-version: [16.x]` and `os: [ubuntu-latest]` for the CI matrix to get it to pass for now

## Details

Per https://github.com/agilgur5/react-signature-canvas/pull/112#issuecomment-2566638360, Node 14 fails to "setup" and Node 16 on other OSes fails to download `node-canvas` prebuilt binaries (and then fails to build).
Node 18+ seemingly require a newer version of `node-canvas` per https://github.com/Automattic/node-canvas/issues/2025#issuecomment-1296110854, so hold off on that for a separate PR.

For now, just get CI working on a single OS and Node version.