### PR TITLE
fix(ci): update `codecov-action` to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,5 @@ jobs:
       run: npm run test:coverage
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,3 @@ jobs:
       run: npm run test:coverage
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
     - name: Test w/ coverage report
       run: npm run test:coverage
     - name: Upload coverage report to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary

Per https://github.com/agilgur5/react-signature-canvas/pull/112#issuecomment-2566699336 and https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token, it seems a newer version of the action is required now for tokenless uploads due to GH rate limiting etc

## Details

- `codecov-action` from `v2` to `v5`
- also had to change a setting in Codecov per [below comment](https://github.com/agilgur5/react-signature-canvas/pull/114#issuecomment-2566708449)