### PR TITLE
docs: update link to new CodeSandbox example

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,10 @@ The API methods are _mostly_ just wrappers around [`signature_pad`'s API](https:
 You can interact with the example in a few different ways:
 
 1. Run `npm start` and navigate to [http://localhost:1234/](http://localhost:1234/).<br>
-Hosted locally via the [`example/`](example/) directory
+   Hosted locally via the [`example/`](example/) directory
+
 1. [View the live demo here](https://agilgur5.github.io/react-signature-canvas/).<br>
-Hosted via the [`gh-pages` branch](https://github.com/agilgur5/react-signature-canvas/tree/gh-pages), a standalone version of the code in [`example/`](example/)
-1. [Play with the CodeSandbox here](https://codesandbox.io/s/github/agilgur5/react-signature-canvas/tree/cra-example).<br>
-Hosted via the [`cra-example` branch](https://github.com/agilgur5/react-signature-canvas/tree/gh-pages), a standalone version using [Create React App](https://github.com/facebook/create-react-app).
+   Hosted via the [`gh-pages` branch](https://github.com/agilgur5/react-signature-canvas/tree/gh-pages), a standalone version of the code in [`example/`](example/)
+
+1. [Play with the CodeSandbox here](https://codesandbox.io/s/github/agilgur5/react-signature-canvas/tree/codesandbox-example).<br>
+   Hosted via the [`codesandbox-example` branch](https://github.com/agilgur5/react-signature-canvas/tree/codesandbox-example), a slightly modified version of the above.


### PR DESCRIPTION
## Summary

Per https://github.com/agilgur5/react-signature-canvas/pull/119#issuecomment-2660163344, the CodeSandbox was migrated off of CRA as it is now deprecated (https://github.com/facebook/create-react-app/pull/17003)

## Details

- the CodeSandbox example now uses Parcel same as the `example/` dir and `gh-pages` branch
  - the branch is now `codesandbox-example` as the name `cra-example` would no longer match
    - left the `cra-example` branch as-is for now, so that any links to it / it's CodeSandbox continue working (still works, just uses older deps) 

- also modify some whitespace in this section for better readability of the raw markdown