### PR TITLE
deps: move peer types to optional peerDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.17.9",
-        "@types/prop-types": "^15.7.3",
-        "@types/react": "^19.0.2",
         "@types/signature_pad": "^2.3.0",
         "signature_pad": "^2.3.2",
         "trim-canvas": "^0.1.0"
@@ -30,6 +28,8 @@
         "@rollup/plugin-commonjs": "^21.1.0",
         "@rollup/plugin-node-resolve": "^13.2.1",
         "@testing-library/react": "^16.1.0",
+        "@types/prop-types": "^15.7.3",
+        "@types/react": "^19.0.2",
         "canvas": "^3.0.0",
         "concurrently": "^9.1.2",
         "jest": "^29.7.0",
@@ -52,9 +52,19 @@
         "url": "https://github.com/sponsors/agilgur5"
       },
       "peerDependencies": {
+        "@types/prop-types": "^15.7.3",
+        "@types/react": "0.14 - 19",
         "prop-types": "^15.5.8",
         "react": "0.14 - 19",
         "react-dom": "0.14 - 19"
+      },
+      "peerDependenciesMeta": {
+        "@types/prop-types": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@agilgur5/changelog-maker": {
@@ -4998,12 +5008,14 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "19.0.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.2.tgz",
       "integrity": "sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==",
+      "dev": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -6444,7 +6456,8 @@
     "node_modules/csstype": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
-      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
+      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==",
+      "dev": true
     },
     "node_modules/data-urls": {
       "version": "3.0.2",
@@ -18076,12 +18089,14 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
     },
     "@types/react": {
       "version": "19.0.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.2.tgz",
       "integrity": "sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==",
+      "dev": true,
       "requires": {
         "csstype": "^3.0.2"
       }
@@ -19173,7 +19188,8 @@
     "csstype": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
-      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
+      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==",
+      "dev": true
     },
     "data-urls": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -64,14 +64,22 @@
     "changelog": "changelog-maker"
   },
   "peerDependencies": {
+    "@types/prop-types": "^15.7.3",
+    "@types/react": "0.14 - 19",
     "prop-types": "^15.5.8",
     "react": "0.14 - 19",
     "react-dom": "0.14 - 19"
   },
+  "peerDependenciesMeta": {
+    "@types/prop-types": {
+      "optional": true
+    },
+    "@types/react": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@babel/runtime": "^7.17.9",
-    "@types/prop-types": "^15.7.3",
-    "@types/react": "^19.0.2",
     "@types/signature_pad": "^2.3.0",
     "signature_pad": "^2.3.2",
     "trim-canvas": "^0.1.0"
@@ -90,6 +98,8 @@
     "@rollup/plugin-commonjs": "^21.1.0",
     "@rollup/plugin-node-resolve": "^13.2.1",
     "@testing-library/react": "^16.1.0",
+    "@types/prop-types": "^15.7.3",
+    "@types/react": "^19.0.2",
     "canvas": "^3.0.0",
     "concurrently": "^9.1.2",
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary

Move `@types/react` and `@types/prop-types` to `optional` `peerDependencies`

## Details

- `react` and `prop-types` are peerDeps, so their `@types/` packages should be too
  - and since they're peers now, we can [mark them as optional](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#peerdependenciesmeta) as well (since they're only needed for TS usage)
  - this should also allow for users to be able to install a range of `@types/react` as well, instead of just v19
    - which could possibly help with the upstream DT issues I found in https://github.com/agilgur5/react-signature-canvas/issues/117#issuecomment-2646819126
  
 ## Future Work
 
 This is in preparation for the v1.1.0 TS release