### PR TITLE
deps: remove no longer used `changelog-maker` devDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "trim-canvas": "^0.1.0"
       },
       "devDependencies": {
-        "@agilgur5/changelog-maker": "^3.0.0",
         "@agilgur5/tsconfig": "^0.0.1",
         "@babel/core": "^7.17.9",
         "@babel/plugin-transform-runtime": "^7.17.0",
@@ -65,60 +64,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@agilgur5/changelog-maker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@agilgur5/changelog-maker/-/changelog-maker-3.0.0.tgz",
-      "integrity": "sha512-UYAxHEsedy21bZw/xzMc6yt4Q8uashoTsbTm+seUJGyXyIalshtIzbLikoYJoChC6JwaYyeLXWnKN3KpBBV/gQ==",
-      "dev": true,
-      "dependencies": {
-        "async": "~2.6.1",
-        "chalk": "~2.4.1",
-        "commit-stream": "~1.1.0",
-        "debug": "~4.1.0",
-        "ghauth": "~3.2.1",
-        "ghissues": "~1.1.3",
-        "gitexec": "~1.0.0",
-        "list-stream": "~1.0.1",
-        "minimist": "~1.2.0",
-        "pkg-to-id": "~0.0.3",
-        "split2": "~3.0.0",
-        "strip-ansi": "~5.0.0"
-      },
-      "bin": {
-        "changelog-maker": "changelog-maker.js"
-      }
-    },
-    "node_modules/@agilgur5/changelog-maker/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@agilgur5/changelog-maker/node_modules/debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@agilgur5/changelog-maker/node_modules/strip-ansi": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-      "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@agilgur5/tsconfig": {
@@ -5263,15 +5208,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -5296,22 +5232,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/application-config": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/application-config/-/application-config-1.0.1.tgz",
-      "integrity": "sha1-WqLipe1qvS5dHUc9NZb1dARP6ec=",
-      "dev": true,
-      "dependencies": {
-        "application-config-path": "^0.1.0",
-        "mkdirp": "^0.5.1"
-      }
-    },
-    "node_modules/application-config-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/application-config-path/-/application-config-path-0.1.0.tgz",
-      "integrity": "sha1-GTxfCoZUGkxm+6Hi3DhYM2LqXo8=",
-      "dev": true
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -5400,15 +5320,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.14"
       }
     },
     "node_modules/asynckit": {
@@ -5698,35 +5609,6 @@
         }
       ]
     },
-    "node_modules/bl": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-      "integrity": "sha512-uVVYHEQk+OuWvCi5U+iquVXvvGCWXKawjwELIR2XMLsqfV/e2sGDClVBs8OlGIgGsStPRY/Es311YKYIlYCWAg==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "~2.0.5"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/bl/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -5819,12 +5701,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
-      "dev": true
     },
     "node_modules/builtin-modules": {
       "version": "3.2.0",
@@ -6062,16 +5938,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
-    "node_modules/commit-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/commit-stream/-/commit-stream-1.1.0.tgz",
-      "integrity": "sha512-+ABU47SlJQFd6z7BwLOujoHrbdxUF42lL3N6lukQLZCbAKdIBiveGFmhVHQOA6+xzPI6YX7KhTV2gTMpWFgG4A==",
-      "dev": true,
-      "dependencies": {
-        "strip-ansi": "~3.0.0",
-        "through2": "~2.0.0"
-      }
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -6212,12 +6078,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
@@ -6728,39 +6588,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
-      "dev": true
-    },
-    "node_modules/duplexer2": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "~1.1.9"
-      }
-    },
-    "node_modules/duplexer2/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
-    },
-    "node_modules/duplexer2/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/duplexer2/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "node_modules/electron-to-chromium": {
@@ -7764,77 +7591,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/ghauth": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ghauth/-/ghauth-3.2.1.tgz",
-      "integrity": "sha512-i3l/FDkE60qO+2UYawL7nPA1Fxz/e9mTz84EuFGP8J2unGVBywzbh9/QI3dW+x8vmsdnfJl8n0Pcph9YbzBwHg==",
-      "dev": true,
-      "dependencies": {
-        "application-config": "~1.0.0",
-        "bl": "~1.1.2",
-        "hyperquest": "~2.0.0",
-        "mkdirp": "~0.5.1",
-        "read": "~1.0.7",
-        "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/ghissues": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ghissues/-/ghissues-1.1.3.tgz",
-      "integrity": "sha1-FS4NolkXAJItJd8PBiwuQy3mmAQ=",
-      "dev": true,
-      "dependencies": {
-        "ghutils": "~3.2.0"
-      }
-    },
-    "node_modules/ghutils": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/ghutils/-/ghutils-3.2.6.tgz",
-      "integrity": "sha512-WpYHgLQkqU7Cv147wKUEThyj6qKHCdnAG2CL9RRsRQImVdLGdVqblJ3JUnj3ToQwgm1ALPS+FXgR0448AgGPUg==",
-      "dev": true,
-      "dependencies": {
-        "jsonist": "~2.1.0",
-        "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/gitexec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gitexec/-/gitexec-1.0.0.tgz",
-      "integrity": "sha512-gm+djiGqPnziuEYHx8oLtmyNnbAWNonS+vXSU+SrvXskeKqFvO5QCKz24t7JTMR+rsjPfFf7o0B5YM/IDh1KXQ==",
-      "dev": true,
-      "dependencies": {
-        "bl": "~1.0.0"
-      }
-    },
-    "node_modules/gitexec/node_modules/bl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
-      "integrity": "sha512-phbvN+yOk05EGoFcV/0S8N8ShnJqf6VCWRAw5he2gvRwBubFt/OzmcTNGqBt5b7Y4RK3YCgf6jrgGSR0Cwtsgw==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "~2.0.5"
-      }
-    },
-    "node_modules/gitexec/node_modules/readable-stream": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/gitexec/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -8088,50 +7844,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/hyperquest": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-2.0.0.tgz",
-      "integrity": "sha1-PRoMXYMpW83lx1qXjdquQJb4PAI=",
-      "dev": true,
-      "dependencies": {
-        "duplexer2": "~0.0.2",
-        "through2": "~0.6.3"
-      }
-    },
-    "node_modules/hyperquest/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
-    },
-    "node_modules/hyperquest/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/hyperquest/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
-    "node_modules/hyperquest/node_modules/through2": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
       }
     },
     "node_modules/iconv-lite": {
@@ -8511,12 +8223,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -10791,12 +10497,6 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -10829,86 +10529,6 @@
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/jsonist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/jsonist/-/jsonist-2.1.2.tgz",
-      "integrity": "sha512-8yqmWJAC2VaYoSKQAbsfgCpGY5o/1etWzx6ZxaZrC4iGaHrHUZEo+a2MyF8w+2uTavTlHdLWaZUoR19UfBstxQ==",
-      "dev": true,
-      "dependencies": {
-        "bl": "~3.0.0",
-        "hyperquest": "~2.1.3",
-        "json-stringify-safe": "~5.0.1",
-        "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/jsonist/node_modules/bl": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.1.tgz",
-      "integrity": "sha512-jrCW5ZhfQ/Vt07WX1Ngs+yn9BDqPL/gw28S7s9H6QK/gupnizNzJAss5akW20ISgOrbLTlXOOCTJeNUQqruAWQ==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "^3.0.1"
-      }
-    },
-    "node_modules/jsonist/node_modules/hyperquest": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-2.1.3.tgz",
-      "integrity": "sha512-fUuDOrB47PqNK/BAMOS13v41UoaqIxqSLHX6CAbOD7OfT+/GCWO1/vPLfTNutOeXrv1ikuaZ3yux+33Z9vh+rw==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^0.1.1",
-        "duplexer2": "~0.0.2",
-        "through2": "~0.6.3"
-      }
-    },
-    "node_modules/jsonist/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
-    },
-    "node_modules/jsonist/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/jsonist/node_modules/through2": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      }
-    },
-    "node_modules/jsonist/node_modules/through2/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/jsonist/node_modules/through2/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.2.2",
@@ -10945,36 +10565,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
-    },
-    "node_modules/list-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/list-stream/-/list-stream-1.0.1.tgz",
-      "integrity": "sha1-40SSrdzNGhZbAorW15WjbE/ZXSk=",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "~2.0.5",
-        "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/list-stream/node_modules/readable-stream": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/list-stream/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "node_modules/lmdb": {
@@ -11200,18 +10790,6 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -11254,12 +10832,6 @@
         "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
         "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
       }
-    },
-    "node_modules/mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
     },
     "node_modules/nan": {
       "version": "2.22.0",
@@ -12003,12 +11575,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pkg-to-id": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/pkg-to-id/-/pkg-to-id-0.0.3.tgz",
-      "integrity": "sha1-NP8zbP9TwnqL9IS8fj0x6mwczKg=",
-      "dev": true
-    },
     "node_modules/postcss": {
       "version": "8.4.49",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
@@ -12226,12 +11792,6 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
-    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -12404,39 +11964,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/read": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-      "dev": true,
-      "dependencies": {
-        "mute-stream": "~0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -13080,29 +12607,6 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
-    "node_modules/split2": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.0.0.tgz",
-      "integrity": "sha512-Cp7G+nUfKJyHCrAI8kze3Q00PFGEG1pMgrAlTFlDbn+GW24evSZHJuMl+iUJx1w/NTRDeBiTgvwnf6YOt94FMw==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "^3.0.0"
-      }
-    },
-    "node_modules/split2/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -13286,18 +12790,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-bom": {
@@ -13563,16 +13055,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
     },
     "node_modules/timsort": {
       "version": "0.3.0",
@@ -14585,15 +14067,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "node_modules/xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/xxhash-wasm": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
@@ -14674,52 +14147,6 @@
     }
   },
   "dependencies": {
-    "@agilgur5/changelog-maker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@agilgur5/changelog-maker/-/changelog-maker-3.0.0.tgz",
-      "integrity": "sha512-UYAxHEsedy21bZw/xzMc6yt4Q8uashoTsbTm+seUJGyXyIalshtIzbLikoYJoChC6JwaYyeLXWnKN3KpBBV/gQ==",
-      "dev": true,
-      "requires": {
-        "async": "~2.6.1",
-        "chalk": "~2.4.1",
-        "commit-stream": "~1.1.0",
-        "debug": "~4.1.0",
-        "ghauth": "~3.2.1",
-        "ghissues": "~1.1.3",
-        "gitexec": "~1.0.0",
-        "list-stream": "~1.0.1",
-        "minimist": "~1.2.0",
-        "pkg-to-id": "~0.0.3",
-        "split2": "~3.0.0",
-        "strip-ansi": "~5.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.0.0"
-          }
-        }
-      }
-    },
     "@agilgur5/tsconfig": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@agilgur5/tsconfig/-/tsconfig-0.0.1.tgz",
@@ -18283,12 +17710,6 @@
         }
       }
     },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
-    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -18307,22 +17728,6 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
-    },
-    "application-config": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/application-config/-/application-config-1.0.1.tgz",
-      "integrity": "sha1-WqLipe1qvS5dHUc9NZb1dARP6ec=",
-      "dev": true,
-      "requires": {
-        "application-config-path": "^0.1.0",
-        "mkdirp": "^0.5.1"
-      }
-    },
-    "application-config-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/application-config-path/-/application-config-path-0.1.0.tgz",
-      "integrity": "sha1-GTxfCoZUGkxm+6Hi3DhYM2LqXo8=",
-      "dev": true
     },
     "arg": {
       "version": "4.1.3",
@@ -18390,15 +17795,6 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.2",
         "es-shim-unscopables": "^1.0.0"
-      }
-    },
-    "async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.14"
       }
     },
     "asynckit": {
@@ -18620,37 +18016,6 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
-    "bl": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-      "integrity": "sha512-uVVYHEQk+OuWvCi5U+iquVXvvGCWXKawjwELIR2XMLsqfV/e2sGDClVBs8OlGIgGsStPRY/Es311YKYIlYCWAg==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~2.0.5"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -18706,12 +18071,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
-    },
-    "buffer-from": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
-      "dev": true
     },
     "builtin-modules": {
       "version": "3.2.0",
@@ -18883,16 +18242,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
-    "commit-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/commit-stream/-/commit-stream-1.1.0.tgz",
-      "integrity": "sha512-+ABU47SlJQFd6z7BwLOujoHrbdxUF42lL3N6lukQLZCbAKdIBiveGFmhVHQOA6+xzPI6YX7KhTV2gTMpWFgG4A==",
-      "dev": true,
-      "requires": {
-        "strip-ansi": "~3.0.0",
-        "through2": "~2.0.0"
-      }
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -18996,12 +18345,6 @@
       "requires": {
         "browserslist": "^4.24.2"
       }
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
     },
     "cosmiconfig": {
       "version": "7.0.1",
@@ -19379,41 +18722,6 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
-    },
-    "duplexer2": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~1.1.9"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
     },
     "electron-to-chromium": {
       "version": "1.5.76",
@@ -20158,79 +19466,6 @@
         "get-intrinsic": "^1.1.1"
       }
     },
-    "ghauth": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ghauth/-/ghauth-3.2.1.tgz",
-      "integrity": "sha512-i3l/FDkE60qO+2UYawL7nPA1Fxz/e9mTz84EuFGP8J2unGVBywzbh9/QI3dW+x8vmsdnfJl8n0Pcph9YbzBwHg==",
-      "dev": true,
-      "requires": {
-        "application-config": "~1.0.0",
-        "bl": "~1.1.2",
-        "hyperquest": "~2.0.0",
-        "mkdirp": "~0.5.1",
-        "read": "~1.0.7",
-        "xtend": "~4.0.1"
-      }
-    },
-    "ghissues": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ghissues/-/ghissues-1.1.3.tgz",
-      "integrity": "sha1-FS4NolkXAJItJd8PBiwuQy3mmAQ=",
-      "dev": true,
-      "requires": {
-        "ghutils": "~3.2.0"
-      }
-    },
-    "ghutils": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/ghutils/-/ghutils-3.2.6.tgz",
-      "integrity": "sha512-WpYHgLQkqU7Cv147wKUEThyj6qKHCdnAG2CL9RRsRQImVdLGdVqblJ3JUnj3ToQwgm1ALPS+FXgR0448AgGPUg==",
-      "dev": true,
-      "requires": {
-        "jsonist": "~2.1.0",
-        "xtend": "~4.0.1"
-      }
-    },
-    "gitexec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gitexec/-/gitexec-1.0.0.tgz",
-      "integrity": "sha512-gm+djiGqPnziuEYHx8oLtmyNnbAWNonS+vXSU+SrvXskeKqFvO5QCKz24t7JTMR+rsjPfFf7o0B5YM/IDh1KXQ==",
-      "dev": true,
-      "requires": {
-        "bl": "~1.0.0"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
-          "integrity": "sha512-phbvN+yOk05EGoFcV/0S8N8ShnJqf6VCWRAw5he2gvRwBubFt/OzmcTNGqBt5b7Y4RK3YCgf6jrgGSR0Cwtsgw==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.0.5"
-          }
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -20413,52 +19648,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
-    },
-    "hyperquest": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-2.0.0.tgz",
-      "integrity": "sha1-PRoMXYMpW83lx1qXjdquQJb4PAI=",
-      "dev": true,
-      "requires": {
-        "duplexer2": "~0.0.2",
-        "through2": "~0.6.3"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          }
-        }
-      }
     },
     "iconv-lite": {
       "version": "0.6.3",
@@ -20715,12 +19904,6 @@
       "requires": {
         "call-bind": "^1.0.2"
       }
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -22419,12 +21602,6 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
-    },
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -22446,87 +21623,6 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
           "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
-        }
-      }
-    },
-    "jsonist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/jsonist/-/jsonist-2.1.2.tgz",
-      "integrity": "sha512-8yqmWJAC2VaYoSKQAbsfgCpGY5o/1etWzx6ZxaZrC4iGaHrHUZEo+a2MyF8w+2uTavTlHdLWaZUoR19UfBstxQ==",
-      "dev": true,
-      "requires": {
-        "bl": "~3.0.0",
-        "hyperquest": "~2.1.3",
-        "json-stringify-safe": "~5.0.1",
-        "xtend": "~4.0.1"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.1.tgz",
-          "integrity": "sha512-jrCW5ZhfQ/Vt07WX1Ngs+yn9BDqPL/gw28S7s9H6QK/gupnizNzJAss5akW20ISgOrbLTlXOOCTJeNUQqruAWQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "^3.0.1"
-          }
-        },
-        "hyperquest": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-2.1.3.tgz",
-          "integrity": "sha512-fUuDOrB47PqNK/BAMOS13v41UoaqIxqSLHX6CAbOD7OfT+/GCWO1/vPLfTNutOeXrv1ikuaZ3yux+33Z9vh+rw==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^0.1.1",
-            "duplexer2": "~0.0.2",
-            "through2": "~0.6.3"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -22557,38 +21653,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
-    },
-    "list-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/list-stream/-/list-stream-1.0.1.tgz",
-      "integrity": "sha1-40SSrdzNGhZbAorW15WjbE/ZXSk=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~2.0.5",
-        "xtend": "~4.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
     },
     "lmdb": {
       "version": "2.2.4",
@@ -22772,15 +21836,6 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
-    "mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.6"
-      }
-    },
     "mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -22817,12 +21872,6 @@
         "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3",
         "node-gyp-build-optional-packages": "5.2.2"
       }
-    },
-    "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
     },
     "nan": {
       "version": "2.22.0",
@@ -23366,12 +22415,6 @@
         }
       }
     },
-    "pkg-to-id": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/pkg-to-id/-/pkg-to-id-0.0.3.tgz",
-      "integrity": "sha1-NP8zbP9TwnqL9IS8fj0x6mwczKg=",
-      "dev": true
-    },
     "postcss": {
       "version": "8.4.49",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
@@ -23519,12 +22562,6 @@
         }
       }
     },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
-    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -23648,38 +22685,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
       "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
       "dev": true
-    },
-    "read": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-      "dev": true,
-      "requires": {
-        "mute-stream": "~0.0.4"
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-          "dev": true
-        }
-      }
     },
     "regenerate": {
       "version": "1.4.2",
@@ -24150,28 +23155,6 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
-    "split2": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.0.0.tgz",
-      "integrity": "sha512-Cp7G+nUfKJyHCrAI8kze3Q00PFGEG1pMgrAlTFlDbn+GW24evSZHJuMl+iUJx1w/NTRDeBiTgvwnf6YOt94FMw==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^3.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -24311,15 +23294,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
-      }
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -24523,16 +23497,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
     },
     "timsort": {
       "version": "0.3.0",
@@ -25234,12 +24198,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "xxhash-wasm": {

--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "test:watch": "jest --watch",
     "test:pub": "npm run clean:build && npm pack",
     "prepub": "concurrently -n test-pub,test-cov,tsc \"npm run test:pub\" \"npm run test:coverage\" \"npm run tsc\"",
-    "pub": "npm run clean:build && npm publish",
-    "changelog": "changelog-maker"
+    "pub": "npm run clean:build && npm publish"
   },
   "peerDependencies": {
     "@types/prop-types": "^15.7.3",
@@ -85,7 +84,6 @@
     "trim-canvas": "^0.1.0"
   },
   "devDependencies": {
-    "@agilgur5/changelog-maker": "^3.0.0",
     "@agilgur5/tsconfig": "^0.0.1",
     "@babel/core": "^7.17.9",
     "@babel/plugin-transform-runtime": "^7.17.0",


### PR DESCRIPTION
## Summary

Remove `@agilgur5/changelog-maker` from devDeps and `scripts`

## Details

- I used [my fork of `changelog-maker`](https://github.com/agilgur5/changelog-maker) for some time, but now my process is more involved
  - I manually categorize, summarize, and minimize changes
    - a good chunk of this could be automated by reading the semantic / conventional commit titles, but not entirely (e.g. when a change can fit multiple types or scopes)
  - I use GitHub Releases' "Generate release notes" feature for the first draft / list of commits + PRs, as with [`v1.1.0-alpha.1`](https://github.com/agilgur5/react-signature-canvas/releases/tag/v1.1.0-alpha.1)
    - unlike `changelog-maker`, GH's feature does not require a `PR-URL: <url>` to exist in the commits to be able to reference the PR
    - I'd like to use a more cross-platform tool that is not reliant on GH, but this is the easiest option right now

- removing this outdated devDep also removes any remaining vulns in the devDeps
  - these didn't affect prod built code and were not exploitable, so were super low priority to fix mainly for less scanner noise

## Future Work
1. [ ] better automate the changelog
1. [ ] make a GH job to publish to NPM and create the GH release
    - start with manual version bumps for now, but with releases via CI