### PR TITLE
fix(pkg): add `types` to `package.json#exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "module": "dist/index.mjs",
   "exports": {
     "require": "./dist/index.umd.min.js",
-    "default": "./dist/index.mjs"
+    "default": "./dist/index.mjs",
+    "types": "./dist/index.d.ts"
   },
   "typings": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
Getting an error when types aren't defined in the exports.

![CleanShot 2025-03-10 at 12 43 09](https://github.com/user-attachments/assets/258d18e2-eb65-44a1-a621-96aa42b5f63d)

This is fixed after adding types to exports.