### PR TITLE
fix(pkg): move `types` above `default`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.umd.min.js",
-    "default": "./dist/index.mjs",
-    "types": "./dist/index.d.ts"
+    "default": "./dist/index.mjs"
   },
   "files": [
     "./src/",


### PR DESCRIPTION
## Summary

Move `exports.types` to be above `exports.default` in `package.json`
Fixes https://github.com/agilgur5/react-signature-canvas/pull/126#discussion_r2017543123

## Details

- Per https://github.com/agilgur5/react-signature-canvas/pull/126#discussion_r2017543123, without this change, types are not properly detected and only happen to work [due to a TS bug](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/6ab2f0a7bf5ab4a64f57fe71df7f58506f227362/docs/problems/FallbackCondition.md) (https://github.com/microsoft/TypeScript/issues/50762. see also https://github.com/microsoft/TypeScript/issues/46334 that has this same issue)