### PR TITLE
ci: pin actions & limit token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: CI - Node ${{ matrix.node-version }}, ${{ matrix.os }}
@@ -12,9 +16,9 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -31,4 +35,4 @@ jobs:
     - name: Test w/ coverage report
       run: npm run test:coverage
     - name: Upload coverage report to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0


### PR DESCRIPTION
## Motivation

Following the [`tj-actions/changed-files` supply chain attack](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) (https://github.com/tj-actions/changed-files/issues/2463), figured I should harden some of my small repos too

## Summary

- follow [OpenSSF Scorecard best practices](https://github.com/ossf/scorecard/blob/43d5832d25ccc597a9b94926b6ad43da25204085/docs/checks.md)
  - specifically "Pinned-Dependencies" and "Token-Permissions"

## Details

- Add `permissions: contents: read` to limit GHA token permission to least privilege
- Pin `actions/checkout`, `actions/setup-node`, and `codecov/codecov-action` to SHAs

### Credit

With some automated help from Step Security: https://github.com/step-security-bot/agilgur5_react-signature-canvas/commit/579bdc4613bf8311ee8b128d201541be8a239964

### Prior Art

Similar to my prior work in https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/pull/224, https://github.com/argoproj/argo-workflows/issues/12031, https://github.com/argoproj/argo-workflows/pull/12035, https://github.com/argoproj/argo-workflows/pull/12619, etc

## Future Work

- [ ] In the future, may add [`falco-actions`](https://github.com/falcosecurity/falco-actions) etc for anomaly detection
  - see also https://sysdig.com/blog/detecting-and-mitigating-the-tj-actions-changed-files-supply-chain-attack-cve-2025-30066/
  - based off OSS Falco, more powerful than and without restrictions unlike [`harden-runner`](https://github.com/step-security/harden-runner), although it doesn't have proactive egress blocking via an allowlist as `harden-runner` does 😕
  - right now, _adding_ those actions could arguably add _more_ surface area given the small usage of the current actions (i.e. could be a "premature optimization" of sorts rn)