### PR TITLE
gh: create a bug report issue form + chooser config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,74 @@
+name: Reproducible Bug Report
+description: If you found a bug within `react-signature-canvas` itself and have a minimal reproduction of it. For support requests, use StackOverflow.
+body:
+  # larger description of what this template's intended usage is
+  - type: markdown
+    attributes:
+      value: |
+        This template is to report a reproducible bug within `react-signature-canvas` itself.
+
+        Issues [should _not_](https://docs.github.com/en/get-started/using-github/communicating-on-github) be used for support requests -- use [StackOverflow](https://stackoverflow.com/search?q=react-signature-canvas) for that instead.
+
+        This should _not_ be used for issues with the underlying `signature_pad` -- use [`signature_pad`'s issues](https://github.com/szimek/signature_pad/issues) for that instead.
+
+        Before opening a new issue, please do a [search of existing issues](https://github.com/agilgur5/react-signature-canvas/issues) and :+1: upvote any existing relevant issues instead.
+        Do not open duplicates of existing issues.
+
+  # require that users have searched existing issues
+  - type: checkboxes
+    attributes:
+      label: Have you searched the existing issues?
+      description: Please search to see if an issue already exists for the problem you encountered
+      options:
+        - label: I have searched the existing issues and cannot find my problem
+          required: true
+
+  # require that users provide a minimal reproduction
+  - type: input
+    attributes:
+      label: Provide a link to code that _minimally_ reproduces this bug
+      description: |
+        Link to a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) via a public [CodeSandbox](https://codesandbox.io/s/github/agilgur5/react-signature-canvas/tree/codesandbox-example), StackBlitz project, or GitHub repository.
+
+        _Skipping this or providing an invalid link may result in your issue being summarily closed._
+      placeholder: 'https://codesandbox.io/p/sandbox/my-minimal-react-signature-canvas-bug-reproduction'
+    validations:
+      required: true
+
+  # require that users provide their environment details
+  - type: textarea
+    attributes:
+      label: Provide version numbers for your environment by running the below command
+      description: npx envinfo --npmPackages react-signature-canvas,react,react-dom,typescript --npmGlobalPackages typescript --binaries --browsers --system os
+      render: text # render as a ```text code block
+      # example output to clue in user about what it should look like
+      placeholder: |
+          System:
+            OS: macOS 14.5
+          Binaries:
+            Node: 22.14.0 - ~/.local/share/mise/installs/node/22.14.0/bin/node
+            Yarn: 1.22.19 - /usr/local/bin/yarn
+            npm: 10.9.2 - ~/.local/share/mise/installs/node/22.14.0/bin/npm
+          Browsers:
+            Chrome: 134.0.6998.166
+            Safari: 17.5
+          npmPackages:
+            react: ^19.0.0 => 19.0.0
+            react-dom: ^19.0.0 => 19.0.0
+            react-signature-canvas: ^1.0.7 => 1.0.7
+            typescript: ^4.6.3 => 4.6.4
+    validations:
+      required: true
+
+  # describe the problem
+  - type: textarea
+    attributes:
+      label: Describe the problem, how to reproduce it, and why you believe the behavior is a bug in this library
+      description: What is the current behavior vs. the expected behavior?
+      render: markdown # render directly as markdown
+      # example output to clue in user about what it should look like
+      placeholder: |
+        In the provided reproduction, run `npm run typecheck`. This results in a TypeScript error: `Could not find a declaration file for module 'react-signature-canvas'`.
+        As this library is natively written in TypeScript, I assumed that type declarations should be provided and that a TS build would succeed.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -11,7 +11,9 @@ body:
 
         This should _not_ be used for issues with the underlying `signature_pad` -- use [`signature_pad`'s issues](https://github.com/szimek/signature_pad/issues) for that instead.
 
-        Before opening a new issue, please do a [search of existing issues](https://github.com/agilgur5/react-signature-canvas/issues) and :+1: upvote any existing relevant issues instead.
+        Before opening a new issue, please do a [search of existing issues](https://github.com/agilgur5/react-signature-canvas/issues?q=is%3Aissue). \
+        If a relevant open issue exists, you should :+1: upvote it instead.
+        If a relevant closed issue exists, please follow the directions of the closing comments. \
         Do not open duplicates of existing issues.
 
   # require that users have searched existing issues

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -11,9 +11,9 @@ body:
 
         This should _not_ be used for issues with the underlying `signature_pad` -- use [`signature_pad`'s issues](https://github.com/szimek/signature_pad/issues) for that instead.
 
-        Before opening a new issue, please do a [search of existing issues](https://github.com/agilgur5/react-signature-canvas/issues?q=is%3Aissue). \
+        Before opening a new issue, please do a [search of existing issues](https://github.com/agilgur5/react-signature-canvas/issues?q=is%3Aissue).
         If a relevant open issue exists, you should :+1: upvote it instead.
-        If a relevant closed issue exists, please follow the directions of the closing comments. \
+        If a relevant closed issue exists, please follow the directions of the closing comments.
         Do not open duplicates of existing issues.
 
   # require that users have searched existing issues

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: Search on StackOverflow
+    url: https://stackoverflow.com/search?q=react-signature-canvas
+    about: Use StackOverflow for support questions. Issues are for reproducible bug reports and feature requests.
+  - name: Upstream `signature_pad`'s issues
+    url: https://github.com/szimek/signature_pad/issues
+    about: This library is a wrapper around `signature_pad`. If you have an with `signature_pad` itself (as opposed to this wrapper), please see its issue tracker.


### PR DESCRIPTION
## Summary

Create a GH [issue form](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) for bug reports and a small [template chooser configuration](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser)

## Details

- have gotten a decent number of issues with no reproductions[^1], so finally decided to make that a requirement for bug reports[^2]
  - require a reproduction, environment details from `envinfo`, and an attestation that the issues were searched
    - also have gotten a number of duplicates[^3], some within an hour of each other no less

- in the issue template and in the template chooser, also refer folks to SO for support
  - since more beginners find themselves using this library, make them more aware that issues are for bug reports and not support requests, which are better suited for SO or consulting / contracts (than for volunteer maintainers to help debug every use-case for free).

- add links to an [SO search for `react-signature-canvas`](https://stackoverflow.com/search?q=react-signature-canvas), [SO's MCVE/MRE docs](https://stackoverflow.com/help/minimal-reproducible-example), [upstream `signature_pad`'s issue tracker](https://github.com/szimek/signature_pad/issues), and [GitHub's communication docs](https://docs.github.com/en/get-started/using-github/communicating-on-github)

## Notes to Reviewers

1. I'm not sure how the top-level description or template chooser in general render exactly as GH does not provide a preview of that. Markdown may not be supported in those
1. The `attributes.description` unfortunately goes _under_ the form `input` or `textarea` (but not for `checkboxes`, which is inconsistent 😕 ); there's no way to configure this

### Considerations / Trade-offs

1. I considered making it shorter, but the problem here has been too many unreproducible errors or issues with little to no details, and not too few issues, so err on the side of asking for more at the risk of some not reporting.
1. I considered disabling `blank_issues_enabled`, but there is no feature request template yet or question template etc. If it gets abused, I will disable it as I have had to do elsewhere

## Verification

See preview of the [bug report form](https://github.com/agilgur5/react-signature-canvas/blob/9ec1edd9ab05bd668896c412d502f20486fd1996/.github/ISSUE_TEMPLATE/bug-report.yml) (the chooser is not previewable unfortunately)

## Prior Art

Takes inspiration from my prior work with:
- https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/pull/217: attestations, error log placeholder
- `rollup-plugin-typescript2`: troubleshooting steps (https://github.com/ezolenko/rollup-plugin-typescript2/pull/350), MRE links (https://github.com/ezolenko/rollup-plugin-typescript2/commit/045560cd3747974838fd28f4c799c5e37dc02734 etc), using `envinfo` (https://github.com/ezolenko/rollup-plugin-typescript2/pull/245 etc)

And some inspiration from [Next.js's bug report form](https://github.com/vercel/next.js/blob/caa595ebbeda0f9c463e198b2f551b2ff473dd8e/.github/ISSUE_TEMPLATE/1.bug_report.yml?plain=1): top-level markdown intro, reproduction link directions

[^1]: The [`problem: no repro` label](https://github.com/agilgur5/react-signature-canvas/issues?q=state%3Aopen%20label%3A%22problem%3A%20no%20repro%22) and the [`solution: can't repro` label](https://github.com/agilgur5/react-signature-canvas/issues?q=state%3Aopen%20label%3A%22solution%3A%20can%27t%20repro%22), plus times when a repro was _eventually_ created by me or a user and so the label was removed. Around ~18 in total, which is a significant _proportion_ of issues
[^2]: I also mentioned making an issue template all the way back in https://github.com/agilgur5/react-signature-canvas/issues/38#issuecomment-568366070. Fortunately the deluge of unreproducible issues stopped shortly after that, with a bit of a resurgence recently
[^3]: The [`solution: duplicate` label](https://github.com/agilgur5/react-signature-canvas/issues?q=is%3Aissue%20state%3Aclosed%20label%3A%22solution%3A%20duplicate%22), which has a decent amount of overlap with the non-reproducible ones (likely points to low quality issues in general). Around ~18 in total.